### PR TITLE
Fix deprecated `async_forward_entry_setup` call

### DIFF
--- a/custom_components/kuna/__init__.py
+++ b/custom_components/kuna/__init__.py
@@ -30,6 +30,8 @@ _LOGGER = logging.getLogger(__name__)
 
 KUNA_COMPONENTS = ["binary_sensor", "camera", "switch"]
 
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
 SERVICE_ENABLE_NOTIFICATIONS = "enable_notifications"
 SERVICE_DISABLE_NOTIFICATIONS = "disable_notifications"
 
@@ -70,9 +72,7 @@ async def async_setup_entry(hass, entry):
     hass.data[DOMAIN] = kuna
 
     for component in KUNA_COMPONENTS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async_track_time_interval(hass, kuna.update, update_interval)
 


### PR DESCRIPTION
Inspired by approach in https://github.com/custom-components/nordpool/pull/390